### PR TITLE
fix update password and login/signup navigate

### DIFF
--- a/my-app/src/Components/App.js
+++ b/my-app/src/Components/App.js
@@ -79,7 +79,7 @@ function App() {
           <Route exact path="/homepage" element={<HomepageWithCards location={location} navigated={navigated} categories={categories} favorites={favorites} rangeLimit = {rangeLimit}/>}/>
           <Route exact path="/favorites" element={<Favoritelist favorites={favorites} />}/>
           <Route exact path = "/login" element = {<Login setUsername={setUsername} setNavigated={setNavigated}/>}/>
-          <Route exact path = "/signup" element = {<SignUp/>}/>
+          <Route exact path = "/signup" element = {<SignUp setNavigated={setNavigated}/>}/>
           <Route exact path="/preferences" element={<Preferences preferences={preferences}/>}/>
           <Route exact path="/profile" element={<Profile preferences={preferences} isAuthenticated={isAuthenticated}/>} />
         </Routes>

--- a/my-app/src/Components/Login.js
+++ b/my-app/src/Components/Login.js
@@ -73,6 +73,7 @@ const Login = (props) => {
       }
   
       // Navigate to the homepage after successfully signing in and retrieving user data from Firestore
+      props.setNavigated(true)
       navigate('/homepage')
     } catch (error) {
       console.log(error.code, error.message);

--- a/my-app/src/Components/Profile.js
+++ b/my-app/src/Components/Profile.js
@@ -8,6 +8,8 @@ import UpdateUsername from './ProfilePage/UpdateUsername';
 
 const ProfilePage = (props) => {
   const user = auth.currentUser;
+  // Used to check if the user signed in with email&password (val = password) or google (val = google.com)
+  const userType = user?.providerData[0]["providerId"]; 
 
   if (!props.isAuthenticated) {
     return <div>Loading...</div>;
@@ -30,10 +32,17 @@ const ProfilePage = (props) => {
       <div>
       <UpdateUsername />
       </div>
-      <div className={ProfileCSS['profile-card']}>
+
+      {
+        userType === "password" ?
+        <div className={ProfileCSS['profile-card']}>
         <p className={ProfileCSS['profile-card-title']}>Update Password</p>
-        <UpdatePassword />
-      </div>
+          <UpdatePassword />
+        </div>
+        :
+        null
+      }
+      
     </section>
   );
 };

--- a/my-app/src/Components/ProfilePage/UpdatePassword.jsx
+++ b/my-app/src/Components/ProfilePage/UpdatePassword.jsx
@@ -4,13 +4,17 @@ import * as yup from 'yup';
 import { yupResolver } from "@hookform/resolvers/yup";
 import { updateUserPassword } from '../../firebase'
 import styles from '../../Styles/Profile.module.css';
+import { EmailAuthProvider, getAuth, reauthenticateWithCredential } from 'firebase/auth';
 
 const schema = yup.object().shape({
-  password: yup.string().required()
+  password: yup.string().required(),
+  current_password: yup.string().required(),
+  confirm_password: yup.string().required()
 });
 
 // form to reset password
 export default function PasswordResetForm() {
+  const user = getAuth().currentUser
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState(null)
   const [success, setSuccess] = useState(null)
@@ -18,28 +22,62 @@ export default function PasswordResetForm() {
   const { register, handleSubmit, formState: { errors } } = useForm({
     resolver: yupResolver(schema),
   });
-
+ 
   const onSubmit = async data => {
+    console.log(data.current_password)
+    console.log(data.confirm_password)
     console.log(data.password)
     setSubmitting(true)
     setError(null)
-    // handle password reset
-    const res = await updateUserPassword(data.password)
 
-    // display error/success message based on result
-    if (res?.error) setError(error.message)
-    else {
-      setSuccess("Password updated correctly")
-      setTimeout(() => setSuccess(null), 4000)
+    if(data.current_password !== data.confirm_password) {
+      setError("Your current passwords do not match!")
+      setSubmitting(false)
+      return
     }
 
-    setSubmitting(false)
+    if(data.password === data.current_password) {
+      setError("Please choose a different password than your current password.")
+      setSubmitting(false)
+      return
+    }
+    
+    // Reauthenticate the user to check if the password is correct
+    const credential = EmailAuthProvider.credential(user.email, data.current_password);
+    reauthenticateWithCredential(user, credential)
+    .then( async (res) => {
+      console.log(res)
+      // Update the user password after successful reauthentication
+      const response = await updateUserPassword(data.password)
+
+      if(response.error) {
+        setError("There was an error updating your password..Please try again...")
+        setTimeout(() => setError(null), 3000)
+        setSubmitting(false)
+      }
+      else {
+        console.log(response.message)
+        setSuccess("Password Successfully Updated!")
+        setTimeout(() => setSuccess(null), 3000)
+        setSubmitting(false)
+      }
+      
+    })
+    .catch((error) => {
+      console.log(error)
+      setError("Invalid password entered")
+      setTimeout(() => setError(null), 3000)
+      setSubmitting(false)
+    })
   };
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className={styles['new-password-form']}>
+      <label htmlFor="password">Current Password</label>
+      <input id="current_password" {...register('current_password')} type="password" placeholder="Current Password"/>
+      <input id="confirm_password" {...register('confirm_password')} type="password" placeholder="Confirm Password"/>
       <label htmlFor="password">New Password</label>
-      <input id="password" {...register('password')} type="password" placeholder="******" />
+      <input id="password" {...register('password')} type="password" placeholder="New Password" />
       {errors.password && <p>{errors.password.message}</p>}
 
       <p style={{ color: 'red', fontWeight: 600 }}>{error}</p>

--- a/my-app/src/Components/Signup.js
+++ b/my-app/src/Components/Signup.js
@@ -4,6 +4,7 @@ import { createUserWithEmailAndPassword, GoogleAuthProvider, signInWithPopup } f
 import { auth, db } from '../firebase';
 import LoginCSS from '../Styles/Login.module.css';
 import { doc, setDoc } from 'firebase/firestore';
+import { updateProfile } from 'firebase/auth';
 
 //defaultPreferences object for new users
 export const defaultPreferences = {
@@ -13,7 +14,7 @@ export const defaultPreferences = {
     ratingLimit: "-1",
 };
 
-const Signup = () => {
+const Signup = (props) => {
   const navigate = useNavigate();
 
   const [email, setEmail] = useState('');
@@ -65,6 +66,13 @@ const Signup = () => {
           },
         };
 
+        // Update the username in the authentication profile
+        try {
+        await updateProfile(userCredential.user, { displayName: username });
+        } catch (error) {
+        return { error: "Error updating the username in the authentication profile." };
+        }
+
         // `doc(db, 'users', userData.uid)` creates a document reference for the 'users' collection,
         // using the user's UID as the document ID.
         // `setDoc()` sets the document to the data specified in userData.
@@ -73,7 +81,10 @@ const Signup = () => {
 
         // Store information in firestore
         await setDoc(doc(db, 'users', userData.uid), userData);
-        navigate('/login');
+
+        // Navigate to the homepage after successfully signing in and retrieving user data from Firestore
+        props.setNavigated(true)
+        navigate('/homepage');
       } else {
         console.log('User is not signed in');
       }
@@ -101,7 +112,7 @@ const Signup = () => {
       const user = userCredential.user;
       // Create user data object containing the user's UID, email, and generated username
       const username = user.email.split('@')[0]; // Generate a username from the user's email
-  
+      
       const userData = {
         uid: user.uid,
         email: user.email,
@@ -114,7 +125,10 @@ const Signup = () => {
   
       // Store information in firestore
       await setDoc(doc(db, 'users', userData.uid), userData);
-      navigate('/login');
+
+      // Navigate to the homepage after successfully signing in and retrieving user data from Firestore
+      props.setNavigated(true)
+      navigate('/homepage');
     } catch (error) {
       const errorCode = error.code;
       const errorMessage = error.message;


### PR DESCRIPTION
Changes:

Login & Signup: Fix the navigation to the homepage after sign in. Also set the props for detecting navigation to true so the page loads with the current user information from App.js

Profile.js: Only show update password for email&password users otherwise hide it for google sign in users

UpdatePassword.jsx: Make the user reauthenticate with their current password before changing their password to a new password and fixed any errors with updating the password