### PR TITLE
Change page title format to 'Easy Hangout | PageName'

### DIFF
--- a/my-app/src/Components/App.js
+++ b/my-app/src/Components/App.js
@@ -11,6 +11,7 @@ import 'bootstrap/dist/css/bootstrap.css';
 import { useState, useEffect } from 'react';
 import { auth, db } from '../firebase';
 import { doc, onSnapshot } from "firebase/firestore";
+import PageTitle from './PageTitle';
 
 
 function App() {
@@ -23,9 +24,7 @@ function App() {
   const [isAuthenticated, setIsAuthenticated] = useState(false); // check if user is authenticated
   const [rangeLimit, setRangeLimit] = useState("");
   const [ratingLimit, setRatingLimit] = useState("")
-  const [username, setUsername] = useState('');
-  
-  
+  const [username, setUsername] = useState(''); 
 
   // will mount
   useEffect( () => {
@@ -76,6 +75,7 @@ function App() {
       
       <Router>
         <AppNavbar isAuthenticated={isAuthenticated} username={username} setNavigated={setNavigated} />
+        <PageTitle />
         <Routes>
           {
             isAuthenticated &&

--- a/my-app/src/Components/PageTitle.js
+++ b/my-app/src/Components/PageTitle.js
@@ -1,0 +1,16 @@
+import { usePageTitle } from './usePageTitle';
+import { useEffect } from 'react';
+
+function PageTitle() {
+  const pageTitle = usePageTitle();
+
+  useEffect(() => {
+    const baseTitle = 'Easy Hangout';
+    document.title = `${baseTitle} | ${pageTitle}`;
+  }, [pageTitle]);
+
+  return null;
+}
+
+export default PageTitle;
+

--- a/my-app/src/Components/usePageTitle.js
+++ b/my-app/src/Components/usePageTitle.js
@@ -1,0 +1,8 @@
+import { useLocation } from 'react-router-dom';
+
+export function usePageTitle() {
+  const location = useLocation();
+  const pageTitle = location.pathname.split('/').slice(-1)[0];
+  return pageTitle;
+}
+


### PR DESCRIPTION
Updated the page title format throughout the application to follow a more consistent and user-friendly pattern. The new format is "Easy Hangout | PageName", which provides a clearer indication of the current page and enhances the overall user experience.

Changes:
1. `App.js`: imported the `PageTitle` component and placed the `<PageTitle />` component inside the `<Router>` component.
2. `usePageTitle` custom hook to return the current page title based on the location.
3. `PageTitle` component to set the document title using the new format.
Ensured that the title updates correctly when navigating between different pages in the app.