### PR TITLE
Now limits the amount of locations queried based on number of categories

### DIFF
--- a/my-app/functions/index.js
+++ b/my-app/functions/index.js
@@ -6,12 +6,12 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
+
+//For local testing
 /*
-For local testing
 const PORT = 3001; 
 const router = express.Router();
 const router1 = express.Router();
-
 */
 
 const app = express();
@@ -19,7 +19,7 @@ app.use(cors({origin: true}));
 
 
 
-app.get('/api/hangouts/:category/:location/:radius', async (req, res) => {
+app.get('/api/hangouts/:category/:location/:radius/:limit', async (req, res) => {
     axios.get("https://api.yelp.com/v3/businesses/search", {
         headers: {
             Authorization: `Bearer ${process.env.YELP_API_KEY}`
@@ -27,7 +27,8 @@ app.get('/api/hangouts/:category/:location/:radius', async (req, res) => {
         params: {
             term: req.params.category,
             location: req.params.location,
-            radius: req.params.radius
+            radius: req.params.radius,
+            limit: req.params.limit
         }
     })
     .then(response => {
@@ -39,7 +40,7 @@ app.get('/api/hangouts/:category/:location/:radius', async (req, res) => {
     })
 });
 
-app.get('/api/hangouts/:category/:location/', async (req, res) => {
+app.get('/api/hangouts/:category/:location/:limit', async (req, res) => {
     axios.get("https://api.yelp.com/v3/businesses/search", {
         headers: {
             Authorization: `Bearer ${process.env.YELP_API_KEY}`
@@ -47,6 +48,7 @@ app.get('/api/hangouts/:category/:location/', async (req, res) => {
         params: {
             term: req.params.category,
             location: req.params.location,
+            limit: req.params.limit
         }
     })
     .then(response => {
@@ -59,8 +61,9 @@ app.get('/api/hangouts/:category/:location/', async (req, res) => {
 });
 
 
+
+//For local testing
 /*
-For local testing
 app.use(router);
 app.use(router1);
 app.listen(PORT, function(error) {
@@ -71,4 +74,5 @@ app.listen(PORT, function(error) {
     console.log('server listening on PORT', PORT);
 })
 */
+
 export const onHangouts = functions.https.onRequest(app); 

--- a/my-app/src/Services/HangoutService.js
+++ b/my-app/src/Services/HangoutService.js
@@ -5,18 +5,35 @@ import axios from 'axios';
 export async function getHangouts(location, categories, radius) {
     try{
 
+        let limit = 15;
+        const numCategories = Object.keys(categories).length;
+        if (numCategories >= 13) {
+            limit = 3; 
+        } 
+        else if (numCategories > 10) { 
+            limit = 4; 
+        } 
+        else if (numCategories > 8)
+        {
+            limit = 6;
+        }
+        else if  (numCategories > 5) { 
+            limit = 8; 
+         } 
+
+
         categories = categories.filter(category => category !== "");
         const hangoutsPromises = categories.map(async (category) => {
         try{
             if (radius > 0) {
-                //`http://localhost:3001/api/hangouts/${category}/${location}/${radius}` for testing
-               const promise = await axios.get(`https://us-central1-easy-hangout-68597.cloudfunctions.net/onHangouts/api/hangouts/${category}/${location}/${radius}`);
+                //`http://localhost:3001/api/hangouts/${category}/${location}/${radius}/${limit}` for testing
+               const promise = await axios.get(`https://us-central1-easy-hangout-68597.cloudfunctions.net/onHangouts/api/hangouts/${category}/${location}/${radius}/${limit}`);
                return promise.data.businesses.map(business => ({...business, ...{"category":`${category}`} }) );
             }
             else
             {
-                //`http://localhost:3001/api/hangouts/${category}/${location}/` for testing
-                const promise = await axios.get(`https://us-central1-easy-hangout-68597.cloudfunctions.net/onHangouts/api/hangouts/${category}/${location}/`);
+                //`http://localhost:3001/api/hangouts/${category}/${location}/${limit}` for testing
+                const promise = await axios.get(`https://us-central1-easy-hangout-68597.cloudfunctions.net/onHangouts/api/hangouts/${category}/${location}/${limit}`);
                 return promise.data.businesses.map(business => ({...business, ...{"category":`${category}`} }) );
             }
            


### PR DESCRIPTION
This should slightly speed up the delay when dealing with multiple categories, but there is still a limitation of yelp API in how only one term can be queried at a time, meaning there is likely no effective way to handle the random delay when querying lots of categories.

<index.js> Added limit for locations into the route, this function is live on firebase
<HangoutService.js> Adjusted route alongside the change to the function. Uses if statements to limit the amount of terms returned per query based on number of categories, should be easily adjustable later. 